### PR TITLE
Self role assignment addition

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,8 +77,10 @@ Configuration for the bot is stored in [config.json](./config.json.template). Ke
 {
     "token": "your bot token",
     "bot-prefix": "bot command prefix",
+    "guild-id": your guild id,
     "extensions": ["your list of extensions"],
     "extension-data": {
+        "rolemgr": {"role-setup-channel-id": 0},
         "extension name": {"whatever": "arbitrary json"}
     }
 }

--- a/config.json.template
+++ b/config.json.template
@@ -1,8 +1,10 @@
 {
     "token": "your bot token",
     "bot-prefix": "bot command prefix",
+    "guild-id": your guild id,
     "extensions": ["your list of extensions"],
     "extension-data": {
+        "rolemgr": {"role-setup-channel-id": 0},
         "extension name": {"whatever": "arbitrary json"}
     }
 }

--- a/discordbot.py
+++ b/discordbot.py
@@ -39,7 +39,8 @@ def PermCheck(ctx):
 
 
 class Bot(commands.Bot):
-    def __init__(self, database: TinyDB, command_prefix, help_command=commands.bot._default, description=None, **options):
+    def __init__(self, database: TinyDB, config: dict, command_prefix, help_command=commands.bot._default, description=None, **options):
         super().__init__(command_prefix, help_command=help_command,
                          description=description, **options)
         self.db = database
+        self.config = config

--- a/extensions/rolemgr.py
+++ b/extensions/rolemgr.py
@@ -7,27 +7,6 @@ from tinydb import where
 from tinydb.operations import add, subtract
 
 
-# commands to get statistical data for roles
-class RoleStatistics(commands.Cog):
-    def __init__(self, bot):
-        self.bot = bot
-
-    # post an embed with a count of members in all roles for the server
-    @commands.command()
-    async def RoleCount(self, ctx):
-        embed = discord.Embed(title="Roles", color=0x7289DA)
-
-        for role in ctx.guild.roles:
-            role_name = role.name
-
-            if role.name == "@everyone":
-                role_name = "Total members"
-
-            embed.add_field(name=f"{role_name} :", inline=True, value=len(role.members))
-
-        await ctx.send(embed=embed)
-
-
 # handles manual and self role assignment
 class RoleManagement(commands.Cog):
     def __init__(self, bot):
@@ -231,12 +210,7 @@ class RoleManagement(commands.Cog):
                 )
 
 
-def last_cmd_call(ctx):
-    return True
-
-
 def setup(bot):
-    bot.add_cog(RoleStatistics(bot))
     bot.add_cog(RoleManagement(bot))
 
 

--- a/extensions/rolemgr.py
+++ b/extensions/rolemgr.py
@@ -1,21 +1,21 @@
+"""This extension provides cogs tailored to management of roles within a server"""
+from datetime import datetime, timedelta
+
 import discord
-
-from discord import user
-from discord.ext import commands
-from discord.utils import get
-from datetime import datetime
-
-# provides commands to get statistical data for roles
+from discord.ext import commands, tasks
+from tinydb import where
+from tinydb.operations import add, subtract
 
 
+# commands to get statistical data for roles
 class RoleStatistics(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
     # post an embed with a count of members in all roles for the server
     @commands.command()
-    async def RoleCount(self, ctx, ignoreBots=True):
-        embed = discord.Embed(title="Roles", color=0x7289da)
+    async def RoleCount(self, ctx):
+        embed = discord.Embed(title="Roles", color=0x7289DA)
 
         for role in ctx.guild.roles:
             role_name = role.name
@@ -23,14 +23,221 @@ class RoleStatistics(commands.Cog):
             if role.name == "@everyone":
                 role_name = "Total members"
 
-            embed.add_field(name=f"{role_name} :",
-                            inline=True, value=len(role.members))
+            embed.add_field(name=f"{role_name} :", inline=True, value=len(role.members))
 
         await ctx.send(embed=embed)
 
 
+# handles manual and self role assignment
+class RoleManagement(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.data_cache_setup()
+
+    max_assignment_time = timedelta(seconds=20)
+
+    async def CloseSetRole(self, member, message):
+        roles_to_add = []
+        for reaction in message.reactions:
+            if reaction.count > 1:
+                roles_to_add.append(
+                    self.guild.get_role(
+                        self.role_connections.get(where("emoji") == str(reaction))[
+                            "role-id"
+                        ]
+                    )
+                )
+
+        tracked_roles_list = [
+            self.guild.get_role(entry["role-id"]) for entry in self.role_connections
+        ]
+
+        new_roles_list = self.EditList("remove", member.roles, tracked_roles_list)
+        await member.edit(roles=new_roles_list)
+        new_roles_list = self.EditList("add", new_roles_list, roles_to_add)
+        self.tracked_role_messages.remove(where("message-id") == message.id)
+        await member.edit(roles=new_roles_list)
+        await message.delete()
+        await member.send(
+            f'`You have successfully been assigned the roles {["@"+role.name for role in roles_to_add]}!`'
+        )
+
+        self.tracked_role_messages.remove(where("message-id") == message.id)
+
+    def data_cache_setup(self):
+        if self.bot.is_ready():
+            self.tracked_role_messages = self.bot.db.table("rolemgr-tracked-messages")
+            self.role_connections = self.bot.db.table("rolemgr-roles-connection")
+            self.self_assignment_channel = self.bot.get_channel(
+                self.bot.config["extension-data"]["rolemgr"]["role-setup-channel-id"]
+            )
+
+            if self.self_assignment_channel is None:
+                self.self_assignment_channel = self.bot.get_guild(
+                    self.bot.config["guild-id"]
+                ).system_channel
+
+            self.guild = self.bot.get_guild(self.bot.config["guild-id"])
+
+    def EditList(self, argument, list1, list2):
+        return {
+            "add": list1 + list(set(list2) - set(list1)),
+            "remove": list(set(list1) - set(list2)),
+            "replace": list2,
+        }[argument]
+
+    @commands.command()
+    async def SelfRoleStat(self, ctx):
+        try:
+            embed = discord.Embed(title="Self-role assignment stats", color=0x7289DA)
+
+            embed.add_field(
+                name="Self Assignment Channel",
+                value=self.self_assignment_channel.name,
+                inline=False,
+            )
+            embed.add_field(
+                name="Role and emoji associations",
+                value=[
+                    f"{self.guild.get_role(entry['role-id']).mention}: {entry['emoji']}"
+                    for entry in self.role_connections.all()
+                ],
+                inline=False,
+            )
+            embed.add_field(
+                name="Active self role messages",
+                value=len(self.tracked_role_messages.all()),
+                inline=False,
+            )
+
+            await ctx.send(embed=embed)
+        except AttributeError as e:
+            print(e)
+
+    # manually edit roles for members
+    @commands.command()
+    async def RoleEdit(self, ctx, edit_command, *mentions: discord.Role):
+        roles_to_edit = ctx.message.role_mentions
+
+        for member in mentions:
+            try:
+                new_roles_list = self.EditList(
+                    edit_command, member.roles, roles_to_edit
+                )
+                await member.edit(roles=new_roles_list)
+            except Exception as e:
+                await ctx.send(
+                    f"```Could not {edit_command} roles for user {member.name}\n{e}```"
+                )
+
+    # command to associate emoji reactions to roles for self assignment
+    @commands.command()
+    async def ConnectRole(self, ctx, emoji, role: discord.Role):
+        if self.role_connections.get(
+            (where("emoji") == emoji) & (where("role-id") != role.id)
+        ):
+            return await ctx.send(
+                f"```The emoji {emoji} is already under use. Please use another emoji for this role.```"
+            )
+        self.role_connections.upsert(
+            {"emoji": emoji, "role-id": role.id}, where("role-id") == role.id
+        )
+        await ctx.send(f"```associated @{role} to {emoji}```")
+
+    @commands.command()
+    async def SetRoleAssignChannel(self, ctx):
+        self.self_assignment_channel = ctx.channel
+        await ctx.send(
+            f"```set #{ctx.channel.name} as the role self assignment channel```"
+        )
+
+    # start role self-assignment process, requires prior setup of emoji_for_roles
+    @commands.command()
+    @commands.cooldown(
+        rate=1, per=max_assignment_time.total_seconds(), type=commands.BucketType.user
+    )
+    async def SetRole(self, ctx):
+        if ctx.channel != self.self_assignment_channel:
+            return
+
+        role_msg_embed = discord.Embed(color=0x7289DA)
+
+        embed_content = ""
+        for entry in self.role_connections.all():
+            embed_content += f'@{ctx.message.guild.get_role(entry["role-id"]).name}: {entry["emoji"]}\n'
+
+        role_msg_embed.add_field(name="Domain Roles", value=embed_content)
+
+        # send user message with embed
+        tracked_message = await ctx.message.author.send(
+            content=f"Hey {ctx.message.author.name}, please have a look below and choose your roles based on your field(s) of expertise.",
+            embed=role_msg_embed,
+        )
+
+        self.tracked_role_messages.insert(
+            {
+                "user-id": ctx.message.author.id,
+                "message-id": tracked_message.id,
+                "count": 0,
+                "timestamp": datetime.utcnow().__str__(),
+            }
+        )
+
+        # set reactions for message
+        for entry in self.role_connections.all():
+            await tracked_message.add_reaction(entry["emoji"])
+
+    @commands.Cog.listener()
+    async def on_ready(self):
+        self.data_cache_setup()
+        self.tracked_message_delete.start()
+
+    @commands.Cog.listener()
+    async def on_reaction_add(self, reaction, user):
+        # update count on actively tracked message reactions
+        if not user.bot:
+            self.tracked_role_messages.update(
+                add("count", 1), where("message-id") == reaction.message.id
+            )
+
+            member = self.guild.get_member(user.id)
+
+            if (
+                self.tracked_role_messages.get(
+                    where("message-id") == reaction.message.id
+                )["count"]
+                == 3
+            ):
+                await self.CloseSetRole(member=member, message=reaction.message)
+
+    @commands.Cog.listener()
+    async def on_reaction_remove(self, reaction, user):
+        # update count on actively tracked message reactions
+        if not user.bot:
+            self.tracked_role_messages.update(
+                subtract("count", 1), where("message-id") == reaction.message.id
+            )
+
+    @tasks.loop(seconds=1)
+    async def tracked_message_delete(self):
+        for entry in self.tracked_role_messages:
+            message_time = datetime.strptime(entry["timestamp"], "%Y-%m-%d %H:%M:%S.%f")
+            if datetime.utcnow() - message_time > self.max_assignment_time:
+                member = self.guild.get_member(entry["user-id"])
+                message = await member.fetch_message(entry["message-id"])
+                await self.CloseSetRole(member=member, message=message)
+                self.tracked_role_messages.remove(
+                    where("message-id") == entry["message-id"]
+                )
+
+
+def last_cmd_call(ctx):
+    return True
+
+
 def setup(bot):
     bot.add_cog(RoleStatistics(bot))
+    bot.add_cog(RoleManagement(bot))
 
 
 def teardown(bot):

--- a/extensions/statistics.py
+++ b/extensions/statistics.py
@@ -1,0 +1,27 @@
+import discord
+from discord.ext import commands
+
+
+# commands to get statistical data for roles
+class Statistics(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    # post an embed with a count of members in all roles for the server
+    @commands.command()
+    async def RoleCount(self, ctx):
+        embed = discord.Embed(title="Roles", color=0x7289DA)
+
+        for role in ctx.guild.roles:
+            role_name = role.name
+
+            if role.name == "@everyone":
+                role_name = "Total members"
+
+            embed.add_field(name=f"{role_name} :", inline=True, value=len(role.members))
+
+        await ctx.send(embed=embed)
+
+
+def setup(bot):
+    bot.add_cog(Statistics(bot))

--- a/na-bot.py
+++ b/na-bot.py
@@ -1,12 +1,11 @@
-import discord
 import json
-from tinydb import TinyDB
-import traceback
 import sys
-import asyncio
+import traceback
+
+import discord
+from tinydb import TinyDB
 
 import discordbot
-
 
 # load config file and database
 db = TinyDB('database.json')
@@ -14,7 +13,7 @@ with open('config.json') as config_file:
     config = json.load(config_file)
 
 # bot initialization
-bot = discordbot.Bot(database=db, perm_path='perms.json',
+bot = discordbot.Bot(database=db, config=config, perm_path='perms.json',
                      command_prefix=config['bot-prefix'], case_insensitive=True)
 bot.add_check(discordbot.PermCheck)
 
@@ -27,15 +26,15 @@ if __name__ == '__main__':
         try:
             bot.load_extension(extension)
             print(f'{extension} loaded')
-        except Exception as e:
-            print(f'Failed to load extension {extension}', file=sys.stderr)
+        except Exception as exception:
+            print(f'Failed to load extension {extension}\n{exception}', file=sys.stderr)
             traceback.print_exc()
 
 
 @bot.event
 async def on_ready():
     print(f'Logged in as: {bot.user.name}\nWith ID: {bot.user.id}')
-    return await bot.change_presence(activity=discord.Activity(type=discord.ActivityType.watching, name='for howls of pain'))
+    return await bot.change_presence(activity=discord.Activity(type=discord.ActivityType.watching, name='for an opportunity to SPAYM'))
 
 TOKEN = config['token']
 


### PR DESCRIPTION
This pull request focuses on the addition of the self role assignment feature that would take over the job of the formerly used reaction-roles bot. The changes to implement this feature have been listed below.
## discordbot.py
- Added config as a property of discordbot for ease of access in extensions.
## rolemgr.py
- Removed unnecessary imports and sorted remaining imports.
- Removed unnecessary argument in RoleCount.
- Added RoleManagement Class for role self assignment.
## na-bot.py
- Sorted imports.
- Updated discordbot to add config reference.